### PR TITLE
feat: support temp table.

### DIFF
--- a/.github/actions/setup_databend_cluster/action.yml
+++ b/.github/actions/setup_databend_cluster/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "query and meta service version"
     required: true
-    default: "1.2.629-nightly"
+    default: "1.2.655-nightly"
   target:
     description: ""
     required: true

--- a/.github/workflows/test_cluster.yml
+++ b/.github/workflows/test_cluster.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ./.github/actions/setup_databend_cluster
         timeout-minutes: 15
         with:
-          version: '1.2.647-nightly'
+          version: '1.2.655-nightly'
           target: 'x86_64-unknown-linux-gnu'
 
       - name: Test with conn to node 1

--- a/databend-client/src/main/java/com/databend/client/DatabendSession.java
+++ b/databend-client/src/main/java/com/databend/client/DatabendSession.java
@@ -42,6 +42,7 @@ public class DatabendSession {
     // txn
     private String txnState;
     private Boolean needSticky;
+    private Boolean needKeepAlive;
 
     private Map<String, Object> additionalProperties = new HashMap<>();
 
@@ -50,16 +51,18 @@ public class DatabendSession {
             @JsonProperty("database") String database,
             @JsonProperty("settings") Map<String, String> settings,
             @JsonProperty("txn_state") String txnState,
-            @JsonProperty("need_sticky") Boolean needSticky) {
-        this.database = database;
+            @JsonProperty("need_sticky") Boolean needSticky,
+            @JsonProperty("need_keep_alive") Boolean needKeepAlive) {
+            this.database = database;
         this.settings = settings;
         this.txnState = txnState;
         this.needSticky = needSticky != null ? needSticky : false;
+        this.needKeepAlive = needKeepAlive != null ? needKeepAlive: false;
     }
 
     // default
     public static DatabendSession createDefault() {
-        return new DatabendSession(DEFAULT_DATABASE, null, null, false);
+        return new DatabendSession(DEFAULT_DATABASE, null, null, false, false);
     }
 
     public static Builder builder() {
@@ -85,6 +88,11 @@ public class DatabendSession {
     @JsonProperty("need_sticky")
     public Boolean getNeedSticky() {
         return needSticky;
+    }
+
+    @JsonProperty("need_keep_alive")
+    public Boolean getNeedKeepAlive() {
+        return needKeepAlive;
     }
 
     @JsonAnyGetter
@@ -153,7 +161,7 @@ public class DatabendSession {
         }
 
         public DatabendSession build() {
-            return new DatabendSession(database, settings, txnState, false);
+            return new DatabendSession(database, settings, txnState, false, false);
         }
     }
 }

--- a/databend-client/src/main/java/com/databend/client/GlobalCookieJar.java
+++ b/databend-client/src/main/java/com/databend/client/GlobalCookieJar.java
@@ -1,0 +1,30 @@
+package com.databend.client;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class GlobalCookieJar implements CookieJar {
+    private final Map<String, Cookie> cookieStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
+        for (Cookie cookie : cookies) {
+            cookieStore.put(cookie.name(), cookie);
+        }
+    }
+
+    @Override
+    public List<Cookie> loadForRequest(HttpUrl url) {
+        return new ArrayList<>(cookieStore.values());
+    }
+
+    public void add(Cookie cookie) {
+        cookieStore.put(cookie.name(), cookie);
+    }
+}

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDriverUri.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDriverUri.java
@@ -1,8 +1,10 @@
 package com.databend.jdbc;
 
+import com.databend.client.GlobalCookieJar;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
+import okhttp3.Cookie;
 import okhttp3.OkHttpClient;
 
 import java.net.URI;
@@ -414,6 +416,10 @@ public final class DatabendDriverUri {
 
     public void setupClient(OkHttpClient.Builder builder) throws SQLException {
         try {
+            GlobalCookieJar cookieJar = new GlobalCookieJar();
+            cookieJar.add(new Cookie.Builder().name("cookie_enabled").value("true").domain("not_used").build());
+            builder.cookieJar(cookieJar);
+
             String password = PASSWORD.getValue(properties).orElse("");
             if (!password.isEmpty()) {
                 builder.addInterceptor(basicAuthInterceptor(USER.getValue(properties).orElse(""), password));

--- a/databend-jdbc/src/main/java/com/databend/jdbc/NonRegisteringDatabendDriver.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/NonRegisteringDatabendDriver.java
@@ -1,5 +1,7 @@
 package com.databend.jdbc;
 
+import com.databend.client.GlobalCookieJar;
+import okhttp3.Cookie;
 import okhttp3.OkHttpClient;
 
 import java.io.Closeable;
@@ -54,6 +56,9 @@ public class NonRegisteringDatabendDriver implements Driver, Closeable {
         }
 
         DatabendDriverUri uri = DatabendDriverUri.create(url, info);
+
+        GlobalCookieJar cookieJar = new GlobalCookieJar();
+        cookieJar.add(new Cookie.Builder().name("cookie_enabled").value("true").domain("not_used").build());
 
         OkHttpClient.Builder builder = httpClient.newBuilder();
         uri.setupClient(builder);

--- a/databend-jdbc/src/test/java/com/databend/jdbc/TestTempTable.java
+++ b/databend-jdbc/src/test/java/com/databend/jdbc/TestTempTable.java
@@ -1,0 +1,28 @@
+package com.databend.jdbc;
+
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+public class TestTempTable {
+
+    @Test
+    public void testTempTable() throws SQLException {
+        try(Connection c1 = Utils.createConnection()) {
+            Statement statement= c1.createStatement();
+            statement.execute("create or replace temp table table1(i int)");
+            statement.execute("insert into table1 values (1), (2)");
+            statement.executeQuery("select * from table1");
+            ResultSet rs = statement.getResultSet();
+            Assert.assertEquals(true, rs.next());
+            Assert.assertEquals(1, rs.getInt(1));
+            Assert.assertEquals(true, rs.next());
+            Assert.assertEquals(2, rs.getInt(1));
+            Assert.assertEquals(false, rs.next());
+        }
+    }
+}


### PR DESCRIPTION
 temp table have states across query at the server side, need:

1. session id: carried in cookie
2. logout: to clean up the states

after this pr, temp table is available, require databend server version >= 1.2.655 , but since heartbeat is not implemented yet, temp table will be cleaned up after session is idle for 4 hours, it is recommended to drop temp table after use, vacuum is used incase of forget or fail to drop it

unlike https://github.com/databendlabs/bendsql/pull/479, session token is not introduced in the same pr, as it may need bigger refactor
