### PR TITLE
fix: remove presigned url in log

### DIFF
--- a/.github/actions/setup_databend_cluster/action.yml
+++ b/.github/actions/setup_databend_cluster/action.yml
@@ -4,7 +4,7 @@ inputs:
   version:
     description: "query and meta service version"
     required: true
-    default: "1.2.655-nightly"
+    default: "1.2.661-nightly"
   target:
     description: ""
     required: true

--- a/.github/workflows/test_cluster.yml
+++ b/.github/workflows/test_cluster.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: ./.github/actions/setup_databend_cluster
         timeout-minutes: 15
         with:
-          version: '1.2.655-nightly'
+          version: '1.2.661-nightly'
           target: 'x86_64-unknown-linux-gnu'
 
       - name: Test with conn to node 1

--- a/databend-jdbc/src/main/java/com/databend/jdbc/cloud/DatabendPresignClientV1.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/cloud/DatabendPresignClientV1.java
@@ -86,7 +86,7 @@ public class DatabendPresignClientV1 implements DatabendPresignClient {
         try {
             executeInternal(r, true);
         } catch (IOException e) {
-            throw new IOException(format(" uploadFromStream failed, file size is %s,  presignUrl is %s kb, error is %s", fileSize / 1024.0, presignedUrl, e.toString()));
+            throw new IOException(format(" uploadFromStream failed, file size is %s kb, error is %s", fileSize / 1024.0, presignedUrl, e.toString()));
         }
     }
 


### PR DESCRIPTION
The presigned url is sensitive so we need remove it from log.