### PR TITLE
fix: empty password error

### DIFF
--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDriverUri.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendDriverUri.java
@@ -417,9 +417,7 @@ public final class DatabendDriverUri {
             builder.cookieJar(cookieJar);
 
             String password = PASSWORD.getValue(properties).orElse("");
-            if (!password.isEmpty()) {
-                builder.addInterceptor(basicAuthInterceptor(USER.getValue(properties).orElse(""), password));
-            }
+            builder.addInterceptor(basicAuthInterceptor(USER.getValue(properties).orElse(""), password));
             if (useSecureConnection || sslmode.equals("enable")) {
                 setupInsecureSsl(builder);
             }


### PR DESCRIPTION
Now empty password will get such errors:

```
Caused by: java.lang.RuntimeException: Query failed: QueryErrors{code=5100, message=No authorization header detected} 
```