### PR TITLE
feat: re-format the query-id

### DIFF
--- a/databend-client/src/test/java/com/databend/client/TestClientIT.java
+++ b/databend-client/src/test/java/com/databend/client/TestClientIT.java
@@ -76,7 +76,7 @@ public class TestClientIT {
     @Test(groups = {"it"})
     public void testBasicQueryIDHeader() {
         OkHttpClient client = new OkHttpClient.Builder().addInterceptor(OkHttpUtils.basicAuthInterceptor("databend", "databend")).build();
-        String expectedUUID = UUID.randomUUID().toString();
+        String expectedUUID = UUID.randomUUID().toString().replace("-","");
         AtomicReference<String> lastNodeID = new AtomicReference<>();
 
         Map<String, String> additionalHeaders = new HashMap<>();
@@ -85,7 +85,7 @@ public class TestClientIT {
         DatabendClient cli = new DatabendClientV1(client, "select 1", settings, null, lastNodeID);
         Assert.assertEquals(cli.getAdditionalHeaders().get(X_Databend_Query_ID), expectedUUID);
 
-        String expectedUUID1 = UUID.randomUUID().toString();
+        String expectedUUID1 = UUID.randomUUID().toString().replace("-", "");
         Map<String, String> additionalHeaders1 = new HashMap<>();
         additionalHeaders1.put(X_Databend_Query_ID, expectedUUID1);
         ClientSettings settings1 = new ClientSettings(DATABEND_HOST, DatabendSession.createDefault(), DEFAULT_QUERY_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_SOCKET_TIMEOUT, PaginationOptions.defaultPaginationOptions(), additionalHeaders1, null, DEFAULT_RETRY_ATTEMPTS);
@@ -104,7 +104,7 @@ public class TestClientIT {
     @Test(groups = {"it"})
     public void testDiscoverNodes() {
         OkHttpClient client = new OkHttpClient.Builder().addInterceptor(OkHttpUtils.basicAuthInterceptor("databend", "databend")).build();
-        String expectedUUID = UUID.randomUUID().toString();
+        String expectedUUID = UUID.randomUUID().toString().replace("-", "");
 
         Map<String, String> additionalHeaders = new HashMap<>();
         additionalHeaders.put(X_Databend_Query_ID, expectedUUID);
@@ -119,7 +119,7 @@ public class TestClientIT {
     @Test(groups = {"it"})
     public void testDiscoverNodesUnSupported() {
         OkHttpClient client = new OkHttpClient.Builder().addInterceptor(OkHttpUtils.basicAuthInterceptor("databend", "databend")).build();
-        String expectedUUID = UUID.randomUUID().toString();
+        String expectedUUID = UUID.randomUUID().toString().replace("-", "");
 
         Map<String, String> additionalHeaders = new HashMap<>();
         additionalHeaders.put(X_Databend_Query_ID, expectedUUID);

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendConnection.java
@@ -706,7 +706,7 @@ public class DatabendConnection implements Connection, FileTransferAPI, Consumer
 
         for (int attempt = 0; attempt <= maxRetries; attempt++) {
             try {
-                String queryId = UUID.randomUUID().toString();
+                String queryId = UUID.randomUUID().toString().replace("-", "");;
                 String candidateHost = selectHostForQuery(queryId);
 
                 // configure the client settings

--- a/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/DatabendPreparedStatement.java
@@ -164,7 +164,7 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
         File saved = batchInsertUtils.get().saveBatchToCSV(batchValues);
         try (FileInputStream fis = new FileInputStream(saved);) {
             DatabendConnection c = (DatabendConnection) getConnection();
-            String uuid = UUID.randomUUID().toString();
+            String uuid = UUID.randomUUID().toString().replace("-", "");
             // format %Y/%m/%d/%H/%M/%S/fileName.csv
             String stagePrefix = String.format("%s/%s/%s/%s/%s/%s/%s/",
                     LocalDateTime.now().getYear(),
@@ -205,7 +205,7 @@ public class DatabendPreparedStatement extends DatabendStatement implements Prep
         File saved = batchInsertUtils.get().saveBatchToCSV(batchValues);
         try (FileInputStream fis = new FileInputStream(saved);) {
             DatabendConnection c = (DatabendConnection) getConnection();
-            String uuid = UUID.randomUUID().toString();
+            String uuid = UUID.randomUUID().toString().replace("-", "");
             // format %Y/%m/%d/%H/%M/%S/fileName.csv
             String stagePrefix = String.format("%s/%s/%s/%s/%s/%s/%s/",
                     LocalDateTime.now().getYear(),

--- a/databend-jdbc/src/main/java/com/databend/jdbc/StatementInfoWrapper.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/StatementInfoWrapper.java
@@ -30,7 +30,7 @@ public class StatementInfoWrapper {
      * @return the statement that will be sent to the server
      */
     public static StatementInfoWrapper of(@NonNull RawStatement rawStatement) {
-        return of(rawStatement, UUID.randomUUID().toString());
+        return of(rawStatement, UUID.randomUUID().toString().replace("-", ""););
     }
 
     /**

--- a/databend-jdbc/src/main/java/com/databend/jdbc/StatementInfoWrapper.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/StatementInfoWrapper.java
@@ -30,7 +30,7 @@ public class StatementInfoWrapper {
      * @return the statement that will be sent to the server
      */
     public static StatementInfoWrapper of(@NonNull RawStatement rawStatement) {
-        return of(rawStatement, UUID.randomUUID().toString().replace("-", ""););
+        return of(rawStatement, UUID.randomUUID().toString().replace("-", ""));
     }
 
     /**

--- a/databend-jdbc/src/main/java/com/databend/jdbc/StatementUtil.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/StatementUtil.java
@@ -281,7 +281,7 @@ public class StatementUtil {
             Pair<String, String> additionalParams = subQuery.getStatementType() == StatementType.PARAM_SETTING
                     ? ((SetParamRawStatement) subQuery).getAdditionalProperty()
                     : null;
-            subQueries.add(new StatementInfoWrapper(subQueryWithParams, UUID.randomUUID().toString(),
+            subQueries.add(new StatementInfoWrapper(subQueryWithParams, UUID.randomUUID().toString().replace("-", "");,
                     subQuery.getStatementType(), additionalParams, subQuery));
 
         }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/StatementUtil.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/StatementUtil.java
@@ -281,7 +281,7 @@ public class StatementUtil {
             Pair<String, String> additionalParams = subQuery.getStatementType() == StatementType.PARAM_SETTING
                     ? ((SetParamRawStatement) subQuery).getAdditionalProperty()
                     : null;
-            subQueries.add(new StatementInfoWrapper(subQueryWithParams, UUID.randomUUID().toString().replace("-", "");,
+            subQueries.add(new StatementInfoWrapper(subQueryWithParams, UUID.randomUUID().toString().replace("-", ""),
                     subQuery.getStatementType(), additionalParams, subQuery));
 
         }

--- a/databend-jdbc/src/main/java/com/databend/jdbc/parser/BatchInsertUtils.java
+++ b/databend-jdbc/src/main/java/com/databend/jdbc/parser/BatchInsertUtils.java
@@ -87,7 +87,7 @@ public class BatchInsertUtils {
 
     public File saveBatchToCSV(List<String[]> values) {
         // get a temporary directory
-        String id = UUID.randomUUID().toString();
+        String id = UUID.randomUUID().toString().replace("-","");
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
         File tempFile = new File(tempDir, "databend_batch_insert_" + id + ".csv");
         return saveBatchToCSV(values, tempFile);


### PR DESCRIPTION
Because the query-id format in databend query will be changed from `a-b-c-d` to `abcd` in this https://github.com/databendlabs/databend/pull/17947, so the jdbc need to do the same. 
We change the code where generate query-id.

This pr should be merged after the databend query make compatibility.